### PR TITLE
Update URL in \linkedinauthor

### DIFF
--- a/tex/latex/ceurart/ceurart.cls
+++ b/tex/latex/ceurart/ceurart.cls
@@ -1212,8 +1212,7 @@
      \seq_gput_right:Nn \g_ceur_linkedin_seq
        {
          \parsename { #2 }
-         \url{https://www.linkedin.com/profile/view?id=\tl_to_str:n{#1}}%
-         \space(\eadauthor)
+         \url{https://www.linkedin.com/in/\tl_to_str:n{#1}}\space(\eadauthor)%
        }
      }
 


### PR DESCRIPTION
LinkedIn offers better-looking URL format than the one defined in `ceurart.cls`. This PR addresses this issue.

- Before: https://www.linkedin.com/profile/view?id=XXX
- After: https://www.linkedin.com/in/XXX